### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ https://api.noroff.dev/api/v1/old-games
 Using React Router create 2 paths:
 
 - "/" - this should list the games, the code from Lesson Task 2
-- "/game/:slug" - this will display a single game
+- "/game/:id" - this will display a single game
 
-Wrap each result on the home page in a link. This should link to the `game` page with the slug property in the URL, e.g. `/game/capitalism-2`
+Wrap each result on the home page in a link. This should link to the `game` page with the id property in the URL, e.g. `/game/2`
 
-On the `game` page retrieve the slug from the URL, add it to the base API URL and make a fetch request to get that specific game.
+On the `game` page retrieve the id from the URL, add it to the base API URL and make a fetch request to get that specific game.
 
 Use a Spinner component as a loading indicator.
 
 Use an Alert component to display any errors.
 
-Display the name, release date and rating properties. Render the screenshots array in a carousel (image slider).
+Display the name and release date.


### PR DESCRIPTION
The base API URL doesn't work with /game/:slug, but it does with id, /game/:id.

Get request to: https://api.noroff.dev/api/v1/old-games/the-incredible-machine returns {
    "errors": [
        {
            "code": "invalid_type",
            "message": "ID parameter must be a number",
            "path": [
                "id"
            ]
        }
    ],
    "status": "Bad Request",
    "statusCode": 400
}

Get request to https://api.noroff.dev/api/v1/old-games/1 returns {
    "id": 1,
    "slug": "the-incredible-machine",
    "name": "The Incredible Machine",
    "description": "Undoubtedly one of the most unique games ever produced for the PC, The Incredible Machines 1 is a dream come true for anyone who as a child likes to tinker with gadgets and toys. It is a puzzle game par excellence and beyond: you have to use wacky gadgets and tools given for each level to accomplish objectives. Puzzles start out relaxing and get fiendish very quickly, as later levels require not only ingenuity but also precise timing. A true classic.",
    "released": "1993",
    "image": "https://api.noroff.dev/images/old-games/the-incredible-machine.png",
    "genre": [
        "Puzzle"
    ]
}

There is also no rating properties, nor is there any screenshots on this api endpoint, removed it from the text.